### PR TITLE
SELECT、INSERTに関するテストケースの指摘箇所を修正

### DIFF
--- a/src/main/java/com/final_assignment/User.java
+++ b/src/main/java/com/final_assignment/User.java
@@ -1,5 +1,7 @@
 package com.final_assignment;
 
+import java.util.Objects;
+
 public class User {
     private Integer id;
     private String name;
@@ -39,5 +41,18 @@ public class User {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(id, user.id) && Objects.equals(name, user.name) && Objects.equals(email, user.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, email);
     }
 }

--- a/src/main/java/com/final_assignment/UserController.java
+++ b/src/main/java/com/final_assignment/UserController.java
@@ -21,7 +21,7 @@ public class UserController {
 
     @GetMapping("/users/{id}")
     public User findName(@PathVariable("id") int id) {
-        return userService.findName(id);
+        return userService.findById(id);
     }
     @PostMapping("/users")
     public ResponseEntity<UserResponse> insert(@RequestBody UserRequest userRequest, UriComponentsBuilder uriBuilder) {

--- a/src/main/java/com/final_assignment/UserMapper.java
+++ b/src/main/java/com/final_assignment/UserMapper.java
@@ -13,14 +13,14 @@ public interface UserMapper {
     List<User> findByNameStartingWith(String prefix);
 
     @Select("SELECT id, name FROM users WHERE id = #{id}")
-    Optional<User> findName(int id);
+    Optional<User> findById(int id);
 
     @Insert("INSERT INTO users (name, email) VALUES (#{name}, #{email})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void insert(User user);
 
     @Update("UPDATE users SET name = #{name}, email = #{email} WHERE id = #{id}")
-    User update(Integer id, String name, String email);
+    void update(Integer id, String name, String email);
 
     @Delete("DELETE FROM users WHERE id = #{id}")
     void delete(Integer id);

--- a/src/main/java/com/final_assignment/UserMapper.java
+++ b/src/main/java/com/final_assignment/UserMapper.java
@@ -20,7 +20,7 @@ public interface UserMapper {
     void insert(User user);
 
     @Update("UPDATE users SET name = #{name}, email = #{email} WHERE id = #{id}")
-    void update(Integer id, String name, String email);
+    User update(Integer id, String name, String email);
 
     @Delete("DELETE FROM users WHERE id = #{id}")
     void delete(Integer id);

--- a/src/main/java/com/final_assignment/UserService.java
+++ b/src/main/java/com/final_assignment/UserService.java
@@ -22,8 +22,8 @@ public class UserService {
         }
     }
 
-    public User findName(int id) {
-        Optional<User> name = userMapper.findName(id);
+    public User findById(int id) {
+        Optional<User> name = userMapper.findById(id);
         if(name.isPresent()) {
             return name.get();
         } else {
@@ -38,7 +38,7 @@ public class UserService {
     }
 
     public void update(Integer id, String name, String email) {
-        Optional<User> user = userMapper.findName(id);
+        Optional<User> user = userMapper.findById(id);
         if(user.isPresent()) {
             userMapper.update(id, name, email);
         } else {
@@ -47,7 +47,7 @@ public class UserService {
     }
 
     public void delete(Integer id) {
-        Optional<User> user = userMapper.findName(id);
+        Optional<User> user = userMapper.findById(id);
         if(user.isPresent()) {
             userMapper.delete(id);
         } else {

--- a/src/test/java/com/final_assignment/UserServiceTest.java
+++ b/src/test/java/com/final_assignment/UserServiceTest.java
@@ -1,14 +1,19 @@
 package com.final_assignment;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-import static org.mockito.Mockito.doReturn;
+
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.doThrow;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -18,33 +23,63 @@ class UserServiceTest {
 
     @Mock
     private UserMapper userMapper;
+
+    private List<User> mockUsers;
+
+    @BeforeEach
+    void setUp() {
+        List<User> mockUsers = Arrays.asList(
+                new User(1, "yamada", "yamada@example.com"),
+                new User(1, "kobashi", "kobashi@example.com"),
+                new User(1, "akiyama", "akiyama@example.com"),
+                new User(1, "misawa", "misawa@example.com"),
+                new User(1, "takayama", "takayama@example.com")
+                );
+    }
     
     @Test
-    void findByNameStartingWith() {
+    void 全レコードを取得する事() {
+        doReturn(mockUsers).when(userMapper).findAll();
+        List<User> actual = userService.findByNameStartingWith(null);
+        assertThat(actual).isEqualTo(mockUsers);
     }
 
     @Test
-    void 存在するユーザーのIDを指定したときに正常にユーザーが返されること() {
+    void クエリ文字列を指定してレコードを取得できること() {
+        doReturn(List.of(new User(4, "misawa", "misawa@example.com"))).when(userMapper).findByNameStartingWith("m");
+        List<User> actual = userService.findByNameStartingWith("m");
+        assertThat(actual).isEqualTo(List.of(new User(4, "misawa", "misawa@example.com")));
+    }
+
+    @Test
+    void 指定したIDのレコードを取得できること() {
         doReturn(Optional.of(new User(1, "yamada", "yamada@example.com"))).when(userMapper).findName(1);
         User actual = userService.findName(1);
         assertThat(actual).isEqualTo(new User(1, "yamada", "yamada@example.com"));
+        verify(userMapper, times(1)).findName(1);
 
     }
 
     @Test
-    void 存在しないユーザーのIDを指定したときにnameNotFoundが返されること() {
+    void 存在しないIDを指定した場合は例外が発生すること() {
         doThrow(new NameNotFoundException("name not found")).when(userMapper).findName(999);
-        User actual = userService.findName(999);
-        assertThat(actual).isEqualTo("name not found");
+        assertThrows(NameNotFoundException.class, () -> userService.findName(999));
+        verify(userMapper, times(1)).findName(999);
+    }
+
+    @Test
+    void 登録処理を実施するとその内容が期待通りであること() {
+        doNothing().when(userMapper).insert(any(User.class));
+        User actual = userService.insert("jake", "jake@example.com");
+        assertNotNull(actual);
+        assertEquals("jake", actual.getName());
+        assertEquals("jake@example.com", actual.getEmail());
+        verify(userMapper, times(1)).insert(any(User.class));
 
     }
 
     @Test
-    void insert() {
-    }
-
-    @Test
-    void update() {
+    void 更新処理の実行結果が期待通りであること() {
     }
 
     @Test

--- a/src/test/java/com/final_assignment/UserServiceTest.java
+++ b/src/test/java/com/final_assignment/UserServiceTest.java
@@ -9,9 +9,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 
@@ -53,33 +52,33 @@ class UserServiceTest {
 
     @Test
     void 指定したIDのレコードを取得できること() {
-        doReturn(Optional.of(new User(1, "yamada", "yamada@example.com"))).when(userMapper).findName(1);
-        User actual = userService.findName(1);
+        doReturn(Optional.of(new User(1, "yamada", "yamada@example.com"))).when(userMapper).findById(1);
+        User actual = userService.findById(1);
         assertThat(actual).isEqualTo(new User(1, "yamada", "yamada@example.com"));
-        verify(userMapper, times(1)).findName(1);
+        verify(userMapper, times(1)).findById(1);
 
     }
 
     @Test
     void 存在しないIDを指定した場合は例外が発生すること() {
-        doThrow(new NameNotFoundException("name not found")).when(userMapper).findName(999);
-        assertThrows(NameNotFoundException.class, () -> userService.findName(999));
-        verify(userMapper, times(1)).findName(999);
+        doThrow(new NameNotFoundException("name not found")).when(userMapper).findById(999);
+        assertThrows(NameNotFoundException.class, () -> userService.findById(999));
+        verify(userMapper, times(1)).findById(999);
     }
 
     @Test
     void 登録処理を実施するとその内容が期待通りであること() {
-        doNothing().when(userMapper).insert(any(User.class));
-        User actual = userService.insert("jake", "jake@example.com");
-        assertNotNull(actual);
-        assertEquals("jake", actual.getName());
-        assertEquals("jake@example.com", actual.getEmail());
-        verify(userMapper, times(1)).insert(any(User.class));
 
     }
 
     @Test
-    void 更新処理の実行結果が期待通りであること() {
+    void 更新処理の実行すると引数で渡した値に変更されること() {
+
+    }
+
+    @Test
+    void 更新処理の実行結果が例外を発生すること() {
+
     }
 
     @Test

--- a/src/test/java/com/final_assignment/UserServiceTest.java
+++ b/src/test/java/com/final_assignment/UserServiceTest.java
@@ -10,8 +10,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -68,7 +75,12 @@ class UserServiceTest {
 
     @Test
     void 登録処理を実施するとその内容が期待通りであること() {
-
+        doNothing().when(userMapper).insert(any(User.class));
+        User actual = userService.insert("jake", "jake@example.com");
+        assertNotNull(actual);
+        assertEquals("jake", actual.getName());
+        assertEquals("jake@example.com", actual.getEmail());
+        verify(userMapper, times(1)).insert(any(User.class));
     }
 
     @Test
@@ -82,6 +94,10 @@ class UserServiceTest {
     }
 
     @Test
-    void delete() {
+    void 処理を実行すると引数で指定したIdのレコードが削除されること() {
+    }
+
+    @Test
+    void 引数で指定したIdが存在しない時に削除処理を実行すると例外が発生すること() {
     }
 }

--- a/src/test/java/com/final_assignment/UserServiceTest.java
+++ b/src/test/java/com/final_assignment/UserServiceTest.java
@@ -10,15 +10,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -51,7 +51,7 @@ class UserServiceTest {
     }
 
     @Test
-    void クエリ文字列を指定してレコードを取得できること() {
+    void 指定した名前から始まるレコードを取得できること() {
         doReturn(List.of(new User(4, "misawa", "misawa@example.com"))).when(userMapper).findByNameStartingWith("m");
         List<User> actual = userService.findByNameStartingWith("m");
         assertThat(actual).isEqualTo(List.of(new User(4, "misawa", "misawa@example.com")));
@@ -85,12 +85,10 @@ class UserServiceTest {
 
     @Test
     void 更新処理の実行すると引数で渡した値に変更されること() {
-
     }
 
     @Test
     void 更新処理の実行結果が例外を発生すること() {
-
     }
 
     @Test

--- a/src/test/java/com/final_assignment/UserServiceTest.java
+++ b/src/test/java/com/final_assignment/UserServiceTest.java
@@ -1,20 +1,14 @@
 package com.final_assignment;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import javax.lang.model.element.Name;
-import java.time.LocalDate;
 import java.util.Optional;
-import java.util.jar.Attributes;
-import static org.assertj.core.api.ClassBasedNavigableIterableAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -23,7 +17,7 @@ class UserServiceTest {
     private UserService userService;
 
     @Mock
-    private UserService userMapper;
+    private UserMapper userMapper;
     
     @Test
     void findByNameStartingWith() {
@@ -31,9 +25,18 @@ class UserServiceTest {
 
     @Test
     void 存在するユーザーのIDを指定したときに正常にユーザーが返されること() {
-            doReturn(Optional.of(new User(1, "yamada", "yamada@example.com"))).when(userMapper).findName(1);
-            User actual = userService.findName(1);
-            assertThat(actual).isEqualTo(new User(1, "yamada", "yamada@example.com"));
+        doReturn(Optional.of(new User(1, "yamada", "yamada@example.com"))).when(userMapper).findName(1);
+        User actual = userService.findName(1);
+        assertThat(actual).isEqualTo(new User(1, "yamada", "yamada@example.com"));
+
+    }
+
+    @Test
+    void 存在しないユーザーのIDを指定したときにnameNotFoundが返されること() {
+        doThrow(new NameNotFoundException("name not found")).when(userMapper).findName(999);
+        User actual = userService.findName(999);
+        assertThat(actual).isEqualTo("name not found");
+
     }
 
     @Test


### PR DESCRIPTION
# 概要
SELECTとINSERTに関するテストケースの作成(修正)

# 修正箇所
importのワイルドカードを単一インポートに変更
findNameメソッドの名前をfindByIdに変更
Mapperクラスにあるupdateメソッドの戻り値をUserからvoidに変更

以上、指摘箇所修正完了しております。よろしくお願いします。
