### PR TITLE
DBテストの不一致エラーが解消できない。

### DIFF
--- a/src/test/java/com/final_assignment/UserMapperTest.java
+++ b/src/test/java/com/final_assignment/UserMapperTest.java
@@ -1,0 +1,54 @@
+package com.final_assignment;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Optional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserMapperTest {
+
+    @Autowired
+    UserMapper userMapper;
+
+    @Test
+    void findAll() {
+    }
+
+    @Test
+    void findByNameStartingWith() {
+    }
+
+    @Test
+    @Sql(
+            scripts = {"classpath:/sqlannotation/delete-users.sql", "classpath:/sqlannotation/insert-users.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
+    void 指定したIDのユーザを取得出来ること() {
+        Optional<User> actual = userMapper.findById(1);
+        assertThat(actual.get()).isEqualTo(new User(1, "jake", "jake@example.com"));
+
+    }
+
+    @Test
+    void 存在しないIDのを指定した場合は空のOptionalが返ること() {
+    }
+
+    @Test
+    void insert() {
+    }
+
+    @Test
+    void update() {
+    }
+
+    @Test
+    void delete() {
+    }
+}

--- a/src/test/resources/sqlannotation/delete-users.sql
+++ b/src/test/resources/sqlannotation/delete-users.sql
@@ -1,0 +1,1 @@
+DELETE FROM users;

--- a/src/test/resources/sqlannotation/insert-users.sql
+++ b/src/test/resources/sqlannotation/insert-users.sql
@@ -1,0 +1,3 @@
+INSERT INTO users (id, name, email) VALUES (1, "jake", "jake@example.com");
+INSERT INTO users (id, name, email) VALUES (2, "keno", "keno@example.com");
+INSERT INTO users (id, name, email) VALUES (3, "wagnerJr", "wagnerJr@example.com");


### PR DESCRIPTION
# 概要
DBテストケース: 指定したIDのユーザを取得できることを実行するも不一致エラーになってしまう

# 実行手順
![image](https://github.com/Rikiya-Ishikawa/final-assignment/assets/134298452/550d6c0d-e375-4c2d-ad89-44da464a3dac)

# 実行結果
![image](https://github.com/Rikiya-Ishikawa/final-assignment/assets/134298452/d7bf4c5e-7844-442e-9c05-2dfebfcc087a)

insert-users.sqlの中身
![image](https://github.com/Rikiya-Ishikawa/final-assignment/assets/134298452/815f44fc-3a96-4e90-a951-745df84b894f)

