### PR TITLE
削除処理と指定した文字で始まるユーザが存在しないDBテストを作成

### DIFF
--- a/src/main/java/com/final_assignment/UserMapper.java
+++ b/src/main/java/com/final_assignment/UserMapper.java
@@ -1,6 +1,11 @@
 package com.final_assignment;
 
-import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/test/java/com/final_assignment/UserMapperTest.java
+++ b/src/test/java/com/final_assignment/UserMapperTest.java
@@ -9,8 +9,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @MybatisTest
@@ -55,6 +58,17 @@ class UserMapperTest {
         executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
     @Transactional
+    void  指定した文字で始まるユーザが存在しない場合は空の値を返すこと() {
+        List<User> actual = userMapper.findByNameStartingWith("s");
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    @Sql(
+        scripts = {"classpath:/sqlannotation/delete-users.sql", "classpath:/sqlannotation/insert-users.sql"},
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
     void 指定したIDのユーザを取得出来ること() {
         User expectedUser = new User(1, "jake", "jake@example.com");
         Optional<User> actual = userMapper.findById(1);
@@ -88,7 +102,7 @@ class UserMapperTest {
         userMapper.insert(newUser);
         List<User> users = userMapper.findAll();
         assertEquals(4, users.size());
-        assertTrue(users.stream().anyMatch(user -> "soya".equals(user.getName()) && "soya@example.com".equals(user.getEmail())));
+        assertTrue(users.stream().anyMatch(user -> user.getName().equals("soya") && user.getEmail().equals("soya@example.com")));
     }
 
     @Test
@@ -111,6 +125,8 @@ class UserMapperTest {
         executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
     @Transactional
-    void delete() {
+    void 削除処理ができること() {
+        userMapper.delete(1);
+        assertThat(userMapper.findById(1)).isEmpty();
     }
 }


### PR DESCRIPTION
# 概要
削除処理と指定した文字で始まるユーザが存在しないDBテストを作成

# 実行手順
![image](https://github.com/user-attachments/assets/77ba6776-d722-412c-b9f2-8fd0e08aeb6b)

# 実行結果

削除処理
![image](https://github.com/user-attachments/assets/de82da1c-6e98-4329-9149-5ad5e6116ed4)

指定した文字で始まるユーザが存在しない
![image](https://github.com/user-attachments/assets/2ef8cce5-31c3-470f-a37b-b8006bf05677)

