### PR TITLE
結合テスト:登録処理の期待値が見つからないエラーが解消できない

### DIFF
--- a/src/main/java/com/final_assignment/UserController.java
+++ b/src/main/java/com/final_assignment/UserController.java
@@ -18,11 +18,11 @@ public class UserController {
         return userService.findByNameStartingWith(startsWith);
     }
 
-
     @GetMapping("/users/{id}")
     public User findName(@PathVariable("id") int id) {
         return userService.findById(id);
     }
+
     @PostMapping("/users")
     public ResponseEntity<UserResponse> insert(@RequestBody UserRequest userRequest, UriComponentsBuilder uriBuilder) {
         User user = userService.insert(userRequest.getName(), userRequest.getEmail());

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 import java.nio.charset.StandardCharsets;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = FinalAssignmentApplication.class)
 @AutoConfigureMockMvc
@@ -29,7 +30,7 @@ public class UserRestApiIntegrationTest {
     @Transactional
     void ユーザーが全件取得できること() throws Exception {
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/users"))
-            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(status().isOk())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         String expectedResponse = """
@@ -70,7 +71,7 @@ public class UserRestApiIntegrationTest {
     @Transactional
     void 指定したidが取得されること() throws Exception {
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/users/1"))
-            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(status().isOk())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         String expectedResponse = """
@@ -89,6 +90,33 @@ public class UserRestApiIntegrationTest {
     @Transactional
     void 指定したidが存在しない場合は404を返すこと() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/users/6"))
-            .andExpect(MockMvcResultMatchers.status().isNotFound());
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 新しいレコードが追加されること() throws Exception {
+        String wrestler = """
+                    {
+                        "name": "Luis Mante",
+                        "email": "Luis@example.com"
+                    }
+                """;
+
+        String response = mockMvc.perform(MockMvcRequestBuilders.post("/users")
+                .contentType("application/json")
+                .content(wrestler))
+            .andExpect(MockMvcResultMatchers.status().isCreated())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        String expectedResponse = """
+                    {
+                        "name": "Luis Mante",
+                        "email": "Luis@example.com"
+                    }
+                """;
+
+        JSONAssert.assertEquals(expectedResponse, response, JSONCompareMode.LENIENT);
     }
 }


### PR DESCRIPTION
# 概要
登録処理の結合テストを作成したのですが、
期待値が見つからないというエラーが出てしまってテストが失敗しています。
しかし、期待値にどんな値を返すかはソースコード上で指定しています。
にもかかわらず、期待値が見つからないというエラーが発生しています。
エラーメッセージを確認したところ、JSONの順番が逆になっていたので、
それが原因かと思いソースコードをJSONの順番は許容するように書き換えたのですが、
エラーが解消できませんでした。
原因のあてがなくなってしまったので、
エラーが解消できません。アドバイスいただけないでしょうか。

# エラーメッセージ
![image](https://github.com/user-attachments/assets/458400ad-386b-4e16-8156-b324855b37a7)
